### PR TITLE
ci: run tests in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,11 @@ jobs:
         run: uv run mypy smoothify/
 
       - name: Test
-        run: uv run pytest tests/ -x -q
+        # -n 2 overrides the local `-n auto` default: GitHub runners have 4
+        # vCPUs and some tests spawn smoothify's own worker pool, so a smaller
+        # fan-out avoids oversubscribing the runner.
+        run: uv run pytest tests/ -n 2 -x -q
 
       - name: Notebook smoke test
         if: matrix.python-version == '3.11'
-        run: uv run pytest --nbmake examples/*.ipynb -q
+        run: uv run pytest --nbmake examples/*.ipynb -n 2 -q

--- a/README.md
+++ b/README.md
@@ -244,17 +244,17 @@ Smoothify uses [pytest](https://pytest.org/). After cloning the repository, inst
 # Install dependencies (including the dev group)
 uv sync
 
-# Run all tests
+# Run all tests (parallelised across CPU cores by default via pytest-xdist)
 uv run pytest tests/
 
 # Run with coverage
 uv run pytest tests/ --cov=smoothify --cov-report=html
 
-# Run a single test
-uv run pytest tests/test_chaikin.py::TestChaikinCornerCutting::test_simple_square_polygon
+# Run a single test (add `-n 0` to disable parallelism for clearer output)
+uv run pytest tests/test_chaikin.py::TestChaikinCornerCutting::test_simple_square_polygon -n 0
 ```
 
-If you prefer not to use uv, install the dev dependencies into your environment and run `pytest tests/` directly.
+The suite runs in parallel by default (`-n auto` in `pytest.ini`); pass `-n 0` to run serially when debugging. If you prefer not to use uv, install the dev dependencies into your environment and run `pytest tests/` directly.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pre-commit>=4.0",
     "pytest>=8.4.2",
     "pytest-cov>=6.0.0",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.12.2",
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ addopts =
     --strict-markers
     --tb=short
     --color=yes
+    -n auto
+    --dist worksteal
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests


### PR DESCRIPTION
## Summary

Enable parallel test execution with `pytest-xdist` — parallel by default locally, capped at `-n 2` in CI.

- **`pyproject.toml`** — add `pytest-xdist>=3.8.0` to the dev group.
- **`pytest.ini`** — local default `-n auto --dist worksteal`: fans out across all cores, and `worksteal` rebalances the heavy Water-sweep / fuzz tests so one worker doesn't get stuck with them. Full suite ~76s → ~51s locally.
- **CI (`ci.yml`)** — both test steps pass `-n 2`, overriding the auto default. GitHub runners have 4 vCPUs and several tests spawn smoothify's own worker pool (`num_cores=2`/`0`), so a smaller fan-out avoids oversubscribing the runner.
- **README** — document the parallel default and `-n 0` to serialise for debugging.

## Verification
- Local default → 16 workers, 436 passed (~51s).
- CI-style `-n 2` → override honored (2 workers).
- Notebook smoke test under `-n 2` → 4 notebooks pass.

`uv.lock` is gitignored, so CI resolves `pytest-xdist` fresh from `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)